### PR TITLE
Replace Redis with Redis Stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,10 @@ version: "3.7"
 
 services:
   redis:
-    image: 'redis'
+    image: 'redis/redis-stack'
     ports:
       - '6379:6379'
+      - '8001:8001'
   dev:
     image: 'node:latest'
     command: bash -c "cd /app && npm run start:dev"


### PR DESCRIPTION
Recommend you to use Redis Stack instead of redis. With Redis Stack, you can access Redis GUI to access
Further Read: https://developer.redis.com/create/redis-stack/

<img width="874" alt="image" src="https://user-images.githubusercontent.com/313480/174426455-714f9bed-8564-458c-a3f2-21db20f9c13d.png">
